### PR TITLE
Turbo frame shared partials

### DIFF
--- a/turbo-rails/app/controllers/turbo_frames/shared_partials_controller.rb
+++ b/turbo-rails/app/controllers/turbo_frames/shared_partials_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TurboFrames::SharedPartialsController < ApplicationController
+  # provides a reusable route that accepts a partial as a parameter
+  def new
+    render partial: params[:partial],
+           locals: params[:locals],
+           as: params[:as],
+           object: params[:object]
+  end
+
+  def index; end
+end

--- a/turbo-rails/app/views/layouts/_first_partial.html.erb
+++ b/turbo-rails/app/views/layouts/_first_partial.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "first_partial_turbo_frame" do %>
+  <%= tag.p "First Partial" %>
+<% end %>

--- a/turbo-rails/app/views/layouts/_nav.html.erb
+++ b/turbo-rails/app/views/layouts/_nav.html.erb
@@ -1,14 +1,17 @@
 <ul class="nav justify-content-end">
   <li class="nav-item">
-    <a class="nav-link" href="/"></i>Home</a>
-</li>
-<li class="nav-item">
-  <a class="nav-link" href="/rooms">Hotwire Demo</a>
-</li>
-<li class="nav-item">
-  <a class="nav-link" href="/turbo_frames/simple_frames">Simple</a>
-</li>
-<li class="nav-item">
-  <a class="nav-link" href="/turbo_frames/nested_frames">Nested</a>
-</li>
+    <a class="nav-link" href="/">Home</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/rooms">Hotwire Demo</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/turbo_frames/simple_frames">Simple</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/turbo_frames/nested_frames">Nested</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/turbo_frames/shared_partials">Shared Partials</a>
+  </li>
 </ul>

--- a/turbo-rails/app/views/layouts/_second_partial.html.erb
+++ b/turbo-rails/app/views/layouts/_second_partial.html.erb
@@ -1,0 +1,6 @@
+<%= turbo_frame_tag "second_partial_turbo_frame" do %>
+  <%= turbo_frame_tag 'first_partial_turbo_frame' do %>
+    <%= tag.p "Second Partial" %>
+    <%= link_to 'show first partial', new_turbo_frames_shared_partial_path(partial: 'layouts/first_partial') %>
+  <% end %>
+<% end %>

--- a/turbo-rails/app/views/turbo_frames/shared_partials/_path.html.erb
+++ b/turbo-rails/app/views/turbo_frames/shared_partials/_path.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "test" do %>
+<%= tag.p "some text" %>
+<% end %>

--- a/turbo-rails/app/views/turbo_frames/shared_partials/_path.html.erb
+++ b/turbo-rails/app/views/turbo_frames/shared_partials/_path.html.erb
@@ -1,3 +1,0 @@
-<%= turbo_frame_tag "test" do %>
-<%= tag.p "some text" %>
-<% end %>

--- a/turbo-rails/app/views/turbo_frames/shared_partials/_with_locals.html.erb
+++ b/turbo-rails/app/views/turbo_frames/shared_partials/_with_locals.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "with_locals" do  %>
+  <%= tag.p msg %>
+<% end %>

--- a/turbo-rails/app/views/turbo_frames/shared_partials/index.html.erb
+++ b/turbo-rails/app/views/turbo_frames/shared_partials/index.html.erb
@@ -1,0 +1,27 @@
+<%= render partial: 'layouts/nav' %>
+
+<h1 class="mb-5">Partial as a Parameter</h1>
+
+<h3>Render turbo frame with a partial as parameter</h3>
+<%= turbo_frame_tag "first_partial_turbo_frame", src: new_turbo_frames_shared_partial_path(partial: 'layouts/first_partial') %>
+<br>
+<h3>Render nested turbo frame partial as parameter</h3>
+<%= turbo_frame_tag "second_partial_turbo_frame", src: new_turbo_frames_shared_partial_path(partial: 'layouts/second_partial')  %>
+<br>
+<h3>Render partial with locals from the outside</h3>
+<%= link_to 'First Message', 
+    new_turbo_frames_shared_partial_path( 
+        partial: 'with_locals', 
+        locals: { msg: 'This is the first message'}
+    ), 
+    data: { turbo_frame: 'with_locals' } 
+%>
+<%= link_to 'Second Message', 
+    new_turbo_frames_shared_partial_path( 
+        partial: 'with_locals', 
+        locals: { msg: 'This is the second message'}
+    ), 
+    data: { turbo_frame: 'with_locals' } 
+%>
+<%= turbo_frame_tag "with_locals" %>
+<br>

--- a/turbo-rails/config/routes.rb
+++ b/turbo-rails/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   namespace :turbo_frames do
     resources :nested_frames, only: %i[index new show]
+    resources :shared_partials, only: %i[index new]
     resources :simple_frames, only: %i[index new]
   end
 


### PR DESCRIPTION
__Problem:__ Turbo frames require a path to render content. In most cases, the relevant crud is sufficient although there are edge cases where it would be useful to reuse different partials that can be rendered with page interactions.

__Solution:__ Create a controller to render partials with parameters. The path is reusable and takes a number of parameters such as partial location and locals. 